### PR TITLE
fix: Serialize AxeImages to just base 64 png strings.

### DIFF
--- a/src/main/java/com/deque/axe/android/utils/JsonSerializable.java
+++ b/src/main/java/com/deque/axe/android/utils/JsonSerializable.java
@@ -1,15 +1,20 @@
 package com.deque.axe.android.utils;
 
 import com.deque.axe.android.colorcontrast.AxeColor;
+import com.deque.axe.android.colorcontrast.AxeImage;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import com.google.gson.LongSerializationPolicy;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 public interface JsonSerializable {
 
@@ -33,7 +38,9 @@ public interface JsonSerializable {
             return new AxeColor(in.nextString());
           }
         }
-      });
+      }).registerTypeAdapter(AxeImage.class,
+          (JsonSerializer<AxeImage>) (axeImage, type, jsonSerializationContext) ->
+              new JsonPrimitive(axeImage.toBase64Png()));
 
   static GsonBuilder getDefaultBuilder() {
     return DEFAULT_BUILDER;


### PR DESCRIPTION
Modify AxeImage serialization. This would normally be a "breaking" commit, but we're still in a 0.* release.

## Requester Review Items

- [x] Ensure the Pull Request is into develop.
- [x] Test coverage has not gone down.
- [x] Documentation updated or not needed. (Wiki, Issues, etc)
- [x] Angular Type leads to proper Semantic Version.

## Dev Team Review Items

To be filled out by @dequelabs/mobile.

- [x] Ensure the Requester did not lie. Chastise them politely if they did.
- [x] Code Quality review.
- [x] Changes to Axe*.java classes are minimal, appropriate, and versioned properly.
  ~~- Serialized Axe objects have not changed.~~
  - [x] Public API has not changed.

## Code Owner Review Items

To be filled out by @dequelabs/mobileadmin.

- [x] Any Rules package changes lead to proper Semantic Version.
- [x] Security Review.

## Merger Review Items

- [x] Ensure commit message matches title before squashing.


