### PR TITLE
fix: Metadata objects can be built by axe on its own.

### DIFF
--- a/src/main/java/com/deque/axe/android/AxeContext.java
+++ b/src/main/java/com/deque/axe/android/AxeContext.java
@@ -26,19 +26,21 @@ public class AxeContext implements JsonSerializable {
    * @param axeDevice The device the context was built on.
    * @param screenshot The screenshot at the time the Context was built.
    * @param axeEventStream The AccessibilityEvent Stream since the last view refresh.
-   * @param axeMetaData A set of metadata that describes a given run.
    */
   public AxeContext(
       final AxeView axeView,
       final AxeDevice axeDevice,
       final AxeImage screenshot,
-      final AxeEventStream axeEventStream,
-      final AxeMetaData axeMetaData
+      final AxeEventStream axeEventStream
   ) {
     this.axeView = axeView;
     this.axeDevice = axeDevice;
     this.screenshot = screenshot;
     this.axeEventStream = axeEventStream;
-    this.axeMetaData = axeMetaData;
+
+    this.axeMetaData = new AxeMetaData(
+        axeView.appIdentifier(),
+        System.currentTimeMillis()
+    );
   }
 }

--- a/src/main/java/com/deque/axe/android/AxeMetaData.java
+++ b/src/main/java/com/deque/axe/android/AxeMetaData.java
@@ -2,14 +2,14 @@ package com.deque.axe.android;
 
 import com.deque.axe.android.utils.JsonSerializable;
 
-@SuppressWarnings({"FieldCanBeLocal", "unused"})
+@SuppressWarnings({"FieldCanBeLocal", "unused", "WeakerAccess"})
 class AxeMetaData implements JsonSerializable {
 
-  private final String libVersion = getClass().getPackage().getSpecificationVersion();
+  public final String libVersion = getClass().getPackage().getSpecificationVersion();
 
-  private final String appIdentifier;
+  public final String appIdentifier;
 
-  private final long timestamp;
+  public final long timestamp;
 
   AxeMetaData(final String appIdentifier, final long timestamp) {
     this.appIdentifier = appIdentifier;

--- a/src/main/java/com/deque/axe/android/AxeView.java
+++ b/src/main/java/com/deque/axe/android/AxeView.java
@@ -66,6 +66,12 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
   public final AxeView labeledBy;
 
   /**
+   * The packageName that the View belongs to.
+   * FIXME: Make non transient before a 1.0 release.
+   */
+  public final transient String packageName;
+
+  /**
    * Direct copy of the associated Android Property.
    */
   public final String text;
@@ -98,6 +104,8 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
 
     AxeView labeledBy();
 
+    String packageName();
+
     String text();
 
     List<AxeView> children();
@@ -116,6 +124,7 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
       final boolean isEnabled,
       final boolean isImportantForAccessibility,
       final AxeView labeledBy,
+      final String packageName,
       final String text,
       final List<AxeView> children
   ) {
@@ -127,6 +136,7 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
     this.isEnabled = isEnabled;
     this.isImportantForAccessibility = isImportantForAccessibility;
     this.labeledBy = labeledBy;
+    this.packageName = packageName;
     this.text = text;
     this.children = children;
 
@@ -151,9 +161,36 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
         builder.isEnabled(),
         builder.isImportantForAccessibility(),
         builder.labeledBy(),
+        builder.packageName(),
         builder.text(),
         builder.children()
     );
+  }
+
+  /**
+   * Recurse through the view hierarchy and grab the package name of the first
+   * non Android System UI view.
+   * @return A non Android System UI packageName.
+   */
+  @SuppressWarnings("WeakerAccess")
+  public String appIdentifier() {
+
+    final StringBuilder result = new StringBuilder();
+
+    forEachRecursive(instance -> {
+
+      result.setLength(0);
+
+      result.append(instance.packageName);
+
+      if (instance.className.endsWith("ContentFrameLayout")) {
+        return CallBackResponse.STOP;
+      } else {
+        return CallBackResponse.CONTINUE;
+      }
+    });
+
+    return result.toString();
   }
 
   @Override
@@ -272,6 +309,7 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
    * @param matcher A matcher function.
    * @return The list of views that match.
    */
+  @SuppressWarnings("WeakerAccess")
   public List<AxeView> query(final Matcher matcher) {
 
     final ArrayList<AxeView> results = new ArrayList<>();

--- a/src/test/java/com/deque/axe/android/AxeTest.java
+++ b/src/test/java/com/deque/axe/android/AxeTest.java
@@ -126,7 +126,6 @@ public class AxeTest {
         new AxeViewBuilder().build(),
         null,
         null,
-        null,
         null)
     );
 
@@ -168,8 +167,8 @@ public class AxeTest {
         new AxeViewBuilder().build(),
         null,
         null,
-        null,
-        null)
+        null
+        )
     );
 
     Assert.assertTrue(!axeResult.axeRuleResults.isEmpty());
@@ -184,8 +183,8 @@ public class AxeTest {
     axe.run(new AxeContext(new AxeViewBuilder().build(),
         null,
         null,
-        null,
-        null)
+        null
+        )
     );
 
     Assert.assertEquals("Default run should run all rules.",

--- a/src/test/java/com/deque/axe/android/wrappers/AxeViewBuilder.java
+++ b/src/test/java/com/deque/axe/android/wrappers/AxeViewBuilder.java
@@ -128,6 +128,11 @@ public class AxeViewBuilder implements Builder {
     return labeledBy;
   }
 
+  @Override
+  public String packageName() {
+    return "com.placeholder";
+  }
+
   public AxeViewBuilder text(final String newValue) {
     this.text = newValue;
     return this;


### PR DESCRIPTION
Closes: << Issue Number >> OR DELETE

## Requester Review Items

- [ ] Ensure the Pull Request is into develop.
- [ ] Test coverage has not gone down.
- [ ] Documentation updated or not needed. (Wiki, Issues, etc)
- [ ] Angular Type leads to proper Semantic Version.

## Dev Team Review Items

To be filled out by @dequelabs/mobile.

- [ ] Ensure the Requester did not lie. Chastise them politely if they did.
- [ ] Code Quality review.
- [ ] Changes to Axe*.java classes are minimal, appropriate, and versioned properly.
  - [ ] Serialized Axe objects have not changed.
  ~~- Public API has not changed.~~

## Code Owner Review Items

To be filled out by @dequelabs/mobileadmin.

- [ ] Any Rules package changes lead to proper Semantic Version.
- [ ] Security Review.

## Merger Review Items

- [ ] Ensure commit message matches title before squashing.


