### PR TITLE
fix: ignore null-as-string result from NodeInfoCompat viewIdResourceName

### DIFF
--- a/src/main/java/com/deque/axe/android/AxeView.java
+++ b/src/main/java/com/deque/axe/android/AxeView.java
@@ -381,7 +381,7 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
       final StringBuilder result = new StringBuilder();
 
       contentView.children.forEach(axeView -> {
-        if (result.length() == 0) {
+        if (result.length() == 0 && !"null".equals(axeView.viewIdResourceName)) {
           result.append(axeView.viewIdResourceName);
         }
       });


### PR DESCRIPTION
## Requester Review Items

- [x] Ensure the Pull Request is into develop.
- [x] Test coverage has not gone down.
- [x] Documentation updated or not needed. (Wiki, Issues, etc)
- [x] Angular Type leads to proper Semantic Version.

## Dev Team Review Items

To be filled out by @dequelabs/mobile.

- [ ] Ensure the Requester did not lie. Chastise them politely if they did.
- [ ] Code Quality review.
- [ ] Changes to Axe*.java classes are minimal, appropriate, and versioned properly.
  - [ ] Serialized Axe objects have not changed.
  - [ ] Public API has not changed.

## Code Owner Review Items

To be filled out by @dequelabs/mobileadmin.

- [ ] Any Rules package changes lead to proper Semantic Version.
- [ ] Security Review.

## Merger Review Items

- [ ] Ensure commit message matches title before squashing.


