### PR TITLE
breaking: Converts AxeImpact to enum

### DIFF
--- a/src/main/java/com/deque/axe/android/constants/AxeImpact.java
+++ b/src/main/java/com/deque/axe/android/constants/AxeImpact.java
@@ -4,9 +4,13 @@ package com.deque.axe.android.constants;
  * Enums in Android are sketchy, so we have this simple Static class for accessing Impact constants.
  */
 public enum AxeImpact {
-  MINOR(0), MODERATE(1), SERIOUS(2), CRITICAL(3), BLOCKER(4);
+  MINOR(0),
+  MODERATE(1),
+  SERIOUS(2),
+  CRITICAL(3),
+  BLOCKER(4);
 
-  private int impact;
+  private final int impact;
 
   AxeImpact(int impact) {
     this.impact = impact;


### PR DESCRIPTION
This was supposed to be breaking change: https://github.com/dequelabs/axe-android/pull/97

This PR fixes our semantic versioning and nothing else.

## Requester Review Items

- [x] Ensure the Pull Request is into develop.
- [x] Test coverage has not gone down.
- [x] Documentation updated or not needed. (Wiki, Issues, etc)
- [x] Angular Type leads to proper Semantic Version.

## Dev Team Review Items

To be filled out by @dequelabs/mobile.

- [x] Ensure the Requester did not lie. Chastise them politely if they did.
- [x] Code Quality review.
- [x] Changes to Axe*.java classes are minimal, appropriate, and versioned properly.
  - [x] Serialized Axe objects have not changed.
  - [x] Public API has not changed.

## Code Owner Review Items

To be filled out by @dequelabs/mobileadmin.

- [x] Any Rules package changes lead to proper Semantic Version.
- [x] Security Review.

## Merger Review Items

- [ ] Ensure commit message matches title before squashing.


