### PR TITLE
fix: Don't throw NullPointerException if a view's className property is null

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - develop
+                - qa
                 - master
 
   Publish Release Candidate:
@@ -133,7 +133,7 @@ workflows:
           filters:
             branches:
               only:
-                - develop
+                - qa
 
   Publish Release:
     jobs:

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,5 +1,5 @@
 titleOnly: true
-type:
+types:
   - breaking
   - feat
   - feature

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,2 +1,12 @@
-# Always validate the PR title, and ignore the commits
 titleOnly: true
+type:
+  - breaking
+  - feat
+  - feature
+  - fix
+  - docs
+  - style
+  - refactor
+  - perf
+  - test
+  - chore

--- a/src/main/java/com/deque/axe/android/AxeConf.java
+++ b/src/main/java/com/deque/axe/android/AxeConf.java
@@ -156,13 +156,24 @@ public class AxeConf {
 
   public final transient Set<Class<? extends AxeRuleViewHierarchy>> customRules = new HashSet<>();
 
+  /**
+   * A set of AxeRules that will be excluded from result.
+   * @param ruleIds List of ruleIds to ignore.
+   * @param ignore boolean to ignore or not.
+   * @return the AxeConf instance.
+   */
   public AxeConf ignore(final List<String> ruleIds, boolean ignore) {
-    ruleIds.forEach(s -> ignore(s, ignore));
+    for (String s : ruleIds) {
+      ignore(s, ignore);
+    }
     return this;
   }
 
   /**
-   * A set of AxeRules that will be excluded from result.
+   * An AxeRule that will be excluded from result.
+   * @param ruleId ruleId to ignore.
+   * @param ignore boolean to ignore or not.
+   * @return the AxeConf instance.
    */
   public AxeConf ignore(final String ruleId, final boolean ignore) {
     rules.get(ruleId).ignored = ignore;
@@ -209,19 +220,21 @@ public class AxeConf {
 
   private void normalize() {
     // Make sure that all RulesIDs were trying to run are classes we have access to.
-    ruleIds.forEach(s -> {
-      if (!rules.containsKey(s)) {
+    for (String ruleId : ruleIds) {
+      if (!rules.containsKey(ruleId)) {
         throw new RuntimeException("Tried to run a RuleID that doesn't exist.");
       }
-    });
+    }
 
     // Make sure that the RuleIDs list matches the rules data structure.
     ruleIds.clear();
-    rules.forEach((s, ruleConf) -> {
+    for (Map.Entry<String, RuleConf> entry : rules.entrySet()) {
+      String s = entry.getKey();
+      RuleConf ruleConf = entry.getValue();
       if (!ruleConf.ignored) {
         ruleIds.add(s);
       }
-    });
+    }
   }
 
   Set<AxeRule> ruleInstances() {

--- a/src/main/java/com/deque/axe/android/AxePropCalculator.java
+++ b/src/main/java/com/deque/axe/android/AxePropCalculator.java
@@ -53,96 +53,98 @@ class AxePropCalculator implements Comparable<AxePropCalculator>, JsonSerializab
   }
 
   Map<String, String> getCalculatedProps() {
-    switch (className) {
-      case AndroidClassNames.SWITCH:
-      case AndroidClassNames.CHECKBOX:
+    if (className != null) {
+      switch (className) {
+        case AndroidClassNames.SWITCH:
+        case AndroidClassNames.CHECKBOX:
 
-        calculatedProp = new AxePropInterface() {
-          @Override
-          public String getNameProp(String text,
-                                    String contentDescription,
-                                    String labelText,
-                                    String hint) {
+          calculatedProp = new AxePropInterface() {
+            @Override
+            public String getNameProp(String text,
+                                      String contentDescription,
+                                      String labelText,
+                                      String hint) {
 
-            return getPropAfterNullCheck(text) + SPACE
-                    + getPropAfterNullCheck(contentDescription) + SPACE
-                    + getPropAfterNullCheck(labelText);
-          }
-        }.getNameProp(text, contentDescription, labelText, hintText);
+              return getPropAfterNullCheck(text) + SPACE
+                      + getPropAfterNullCheck(contentDescription) + SPACE
+                      + getPropAfterNullCheck(labelText);
+            }
+          }.getNameProp(text, contentDescription, labelText, hintText);
 
-        setCalculatedProp(Props.NAME.getProp(), calculatedProp);
+          setCalculatedProp(Props.NAME.getProp(), calculatedProp);
 
-        calculatedProp = new AxePropInterface() {
-          @Override
-          public String getStateProp(String state) {
-            return isEnabled ? "enabled" : "disabled";
-          }
-        }.getStateProp("");
+          calculatedProp = new AxePropInterface() {
+            @Override
+            public String getStateProp(String state) {
+              return isEnabled ? "enabled" : "disabled";
+            }
+          }.getStateProp("");
 
-        setCalculatedProp(Props.STATE.getProp(), calculatedProp);
+          setCalculatedProp(Props.STATE.getProp(), calculatedProp);
 
-        break;
-      case AndroidClassNames.EDIT_TEXT:
-        calculatedProp = new AxePropInterface() {
-          @Override
-          public String getNameProp(String text,
-                                    String contentDescription,
-                                    String labelText,
-                                    String hint) {
-            if (!AxeTextUtils.isNullOrEmpty(contentDescription)
-                    && !AxeTextUtils.isNullOrEmpty(hint)) {
+          break;
+        case AndroidClassNames.EDIT_TEXT:
+          calculatedProp = new AxePropInterface() {
+            @Override
+            public String getNameProp(String text,
+                                      String contentDescription,
+                                      String labelText,
+                                      String hint) {
+              if (!AxeTextUtils.isNullOrEmpty(contentDescription)
+                      && !AxeTextUtils.isNullOrEmpty(hint)) {
                 return getPropAfterNullCheck(hint) + SPACE
                         + getPropAfterNullCheck(labelText);
-            } else {
+              } else {
                 return getPropAfterNullCheck(contentDescription) + SPACE
                         + getPropAfterNullCheck(hint) + SPACE
                         + getPropAfterNullCheck(labelText);
-                }
+              }
             }
           }.getNameProp(text, contentDescription, labelText, hintText);
 
-        setCalculatedProp(Props.NAME.getProp(), calculatedProp);
+          setCalculatedProp(Props.NAME.getProp(), calculatedProp);
 
-        calculatedProp = new AxePropInterface() {
-          @Override
-          public String getValueProp(String value) {
-            return text;
-          }
-        }.getValueProp(text);
+          calculatedProp = new AxePropInterface() {
+            @Override
+            public String getValueProp(String value) {
+              return text;
+            }
+          }.getValueProp(text);
 
-        setCalculatedProp(Props.VALUE.getProp(), calculatedProp);
+          setCalculatedProp(Props.VALUE.getProp(), calculatedProp);
 
-        break;
-      case AndroidClassNames.TEXT_VIEW:
-        calculatedProp = new AxePropInterface() {
-          @Override
-          public String getValueProp(String value) {
-            return text;
-          }
-        }.getValueProp(text);
+          break;
+        case AndroidClassNames.TEXT_VIEW:
+          calculatedProp = new AxePropInterface() {
+            @Override
+            public String getValueProp(String value) {
+              return text;
+            }
+          }.getValueProp(text);
 
-        setCalculatedProp(Props.VALUE.getProp(), calculatedProp);
+          setCalculatedProp(Props.VALUE.getProp(), calculatedProp);
 
-        break;
-      case AndroidClassNames.IMAGE_VIEW:
-        calculatedProp = new AxePropInterface() {
-          @Override
-          public String getNameProp(String text,
-                                    String contentDescription,
-                                    String labelText,
-                                    String hint) {
-            return getPropAfterNullCheck(text) + SPACE
-                    + getPropAfterNullCheck(contentDescription) + SPACE
-                    + getPropAfterNullCheck(labelText);
+          break;
+        case AndroidClassNames.IMAGE_VIEW:
+          calculatedProp = new AxePropInterface() {
+            @Override
+            public String getNameProp(String text,
+                                      String contentDescription,
+                                      String labelText,
+                                      String hint) {
+              return getPropAfterNullCheck(text) + SPACE
+                      + getPropAfterNullCheck(contentDescription) + SPACE
+                      + getPropAfterNullCheck(labelText);
             }
           }.getNameProp(text, contentDescription, labelText, hintText);
 
-        setCalculatedProp(Props.NAME.getProp(), calculatedProp);
+          setCalculatedProp(Props.NAME.getProp(), calculatedProp);
 
-        break;
+          break;
 
-      default:
-        break;
+        default:
+          break;
+      }
     }
     return propMap;
   }

--- a/src/main/java/com/deque/axe/android/AxeView.java
+++ b/src/main/java/com/deque/axe/android/AxeView.java
@@ -488,13 +488,13 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
 
       final StringBuilder result = new StringBuilder();
 
-      contentView.children.forEach(axeView -> {
+      for (AxeView axeView : contentView.children) {
         if (result.length() == 0
                 && axeView.viewIdResourceName != null
                 && !"null".equals(axeView.viewIdResourceName)) {
           result.append(axeView.viewIdResourceName);
         }
-      });
+      }
 
       return result.toString();
     }

--- a/src/main/java/com/deque/axe/android/constants/AxeImpact.java
+++ b/src/main/java/com/deque/axe/android/constants/AxeImpact.java
@@ -4,9 +4,13 @@ package com.deque.axe.android.constants;
  * Enums in Android are sketchy, so we have this simple Static class for accessing Impact constants.
  */
 public enum AxeImpact {
-  MINOR(0), MODERATE(1), SERIOUS(2), CRITICAL(3), BLOCKER(4);
+  MINOR(0),
+  MODERATE(1),
+  SERIOUS(2),
+  CRITICAL(3),
+  BLOCKER(4);
 
-  private int impact;
+  private final int impact;
 
   AxeImpact(int impact) {
     this.impact = impact;

--- a/src/main/java/com/deque/axe/android/rules/hierarchy/ActiveViewName.java
+++ b/src/main/java/com/deque/axe/android/rules/hierarchy/ActiveViewName.java
@@ -22,7 +22,8 @@ public class ActiveViewName extends ActiveView {
   @Override
   public boolean isApplicable(AxeProps axeProps) {
     final String className = axeProps.get(Name.CLASS_NAME, String.class);
-    if (className.equals(AndroidClassNames.CHECKBOX)
+    if (className == null
+            || className.equals(AndroidClassNames.CHECKBOX)
             || className.equals(AndroidClassNames.SWITCH)) {
       return false;
     }

--- a/src/test/java/com/deque/axe/android/AxeViewTest.java
+++ b/src/test/java/com/deque/axe/android/AxeViewTest.java
@@ -171,6 +171,29 @@ public class AxeViewTest {
   }
 
   @Test
+  public void calculateProps_nullClassName() {
+    AxeViewBuilder labelAxeViewBuilder = new AxeViewBuilder();
+    labelAxeViewBuilder.text("Control");
+
+    AxeView labelAxeView = labelAxeViewBuilder.build();
+
+    AxeViewBuilder parent = new AxeViewBuilder();
+    parent.text("Control Switch");
+    parent.contentDescription("Switch Control");
+    parent.labeledBy(labelAxeView);
+    parent.isEnabled(true);
+    parent.className(null);
+
+    AxeView axeView = parent.build();
+
+    assertEquals(axeView.calculatedProps.size(), 4);
+    assertEquals(axeView.calculatedProps.get("name"), "Control Switch Switch Control");
+    assertNull(axeView.calculatedProps.get("role"));
+    assertNull(axeView.calculatedProps.get("value"));
+    assertNull(axeView.calculatedProps.get("state"));
+  }
+
+  @Test
   public void calculateProps_switch() {
     AxeViewBuilder labelAxeViewBuilder = new AxeViewBuilder();
     labelAxeViewBuilder.text("Control");

--- a/src/test/java/com/deque/axe/android/rules/hierarchy/ActiveViewNameTest.java
+++ b/src/test/java/com/deque/axe/android/rules/hierarchy/ActiveViewNameTest.java
@@ -31,6 +31,16 @@ public class ActiveViewNameTest {
   }
 
   @Test
+  public void isApplicable_classNameIsNull() {
+    when(axeProps.get(AxeProps.Name.CLASS_NAME, String.class)).thenReturn(null);
+    when(axeProps.get(AxeProps.Name.IS_CLICKABLE, Boolean.class)).thenReturn(true);
+    when(axeProps.get(AxeProps.Name.OVERRIDES_ACCESSIBILITY_DELEGATE, Boolean.class))
+            .thenReturn(false);
+
+    assertFalse(subject.isApplicable(axeProps));
+  }
+
+  @Test
   public void isApplicable_classNameIsButton() {
     when(axeProps.get(AxeProps.Name.CLASS_NAME, String.class)).thenReturn("android.widget.Button");
     when(axeProps.get(AxeProps.Name.IS_CLICKABLE, Boolean.class)).thenReturn(true);


### PR DESCRIPTION
Closes: #127 

There are multiple places where axe-android either uses `switch(className)` or `(className.Equals)`. The Android docs never explicitly say if this value can be null. This change simply avoids a NullPointerException in cases where className is set to null.

## Requester Review Items

- [x] Ensure the Pull Request is into develop.
- [x] Test coverage has not gone down.
- [n/a] Documentation updated or not needed. (Wiki, Issues, etc)
- [x] Angular Type leads to proper Semantic Version.

## Dev Team Review Items

To be filled out by @dequelabs/mobile.

- [ ] Ensure the Requester did not lie. Chastise them politely if they did.
- [ ] Code Quality review.
- [ ] Changes to Axe*.java classes are minimal, appropriate, and versioned properly.
  - [ ] Serialized Axe objects have not changed.
  - [ ] Public API has not changed.

## Code Owner Review Items

To be filled out by @dequelabs/mobileadmin.

- [ ] Any Rules package changes lead to proper Semantic Version.
- [ ] Security Review.

## Merger Review Items

- [ ] Ensure commit message matches title before squashing.


