### PR TITLE
chore: Update release process.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,7 @@ jobs:
   Build and Test:
     <<: *configure_machine
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "4e:6c:aa:95:b0:8b:3f:9b:68:32:c9:d9:8e:fa:25:e0"
+      - add_ssh_keys
       - *load_repo
       - *python_deps
       - checkout
@@ -95,9 +93,7 @@ jobs:
   Publish Beta:
     <<: *configure_machine
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "4e:6c:aa:95:b0:8b:3f:9b:68:32:c9:d9:8e:fa:25:e0"
+      - add_ssh_keys
       - *load_repo
       - *python_deps
       - checkout
@@ -111,10 +107,7 @@ jobs:
   Release:
     <<: *configure_machine
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "bb:e9:c0:14:a4:f6:1d:2b:91:cb:0a:f0:aa:93:79:fc"
-            - "4e:6c:aa:95:b0:8b:3f:9b:68:32:c9:d9:8e:fa:25:e0"
+      - add_ssh_keys
       - checkout
       - *python_deps
       - *checkout_all


### PR DESCRIPTION
As long as the private SSH key is within our CircleCI project settings, we do not need to specify the ssh key fingerprint.  I am unsure what the other fingerprint was for in the "release" job, but if that fingerprint is needed, consider adding the private key to the project settings.

## Requester Review Items

- [x] Ensure the Pull Request is into develop.
- [x] Test coverage has not gone down.
- [x] Documentation updated or not needed. (Wiki, Issues, etc)
- [x] Angular Type leads to proper Semantic Version.

## Dev Team Review Items

To be filled out by @dequelabs/mobile.

- [x] Ensure the Requester did not lie. Chastise them politely if they did.
- [x] Code Quality review.
- [x] Changes to Axe*.java classes are minimal, appropriate, and versioned properly.
  - [x] Serialized Axe objects have not changed.
  - [x] Public API has not changed.

## Code Owner Review Items

To be filled out by @dequelabs/mobileadmin.

- [x] Any Rules package changes lead to proper Semantic Version.
- [x] Security Review.

## Merger Review Items

- [x] Ensure commit message matches title before squashing.


