### PR TITLE
chore: Remove findbugs-annotations dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,11 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.7.22'
 }
 
+configurations.all { config ->
+    config.exclude group: 'com.google.code.findbugs'
+    config.exclude group: 'net.jcip', module: 'jcip-annotations'
+}
+
 apply plugin: 'jacoco'
 
 jacoco {

--- a/build.gradle
+++ b/build.gradle
@@ -42,13 +42,6 @@ repositories {
     mavenCentral()
 }
 
-configurations {
-    spotbugsConfig {
-        canBeConsumed(false)
-        canBeResolved(false)
-    }
-}
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
@@ -60,7 +53,6 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.7.22'
 
-    spotbugsConfig "com.google.code.findbugs:annotations:3.0.1"
 }
 
 apply plugin: 'jacoco'

--- a/build.gradle
+++ b/build.gradle
@@ -136,12 +136,12 @@ task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
 }
 
-version = "TEST_JAR94"
+version = project.hasProperty('versionName') ? project.versionName : 'NOT_A_VERSION_NAME'
 
-//if (!(hasProperty('DQ_MAVEN_CENTRAL_USERNAME') && hasProperty('DQ_MAVEN_CENTRAL_APIKEY'))) {
-//    print ("No artifactory Info. Maven Central Publishing impossible.")
-//    return
-//}
+if (!(hasProperty('DQ_MAVEN_CENTRAL_USERNAME') && hasProperty('DQ_MAVEN_CENTRAL_APIKEY'))) {
+    print ("No artifactory Info. Maven Central Publishing impossible.")
+    return
+}
 
 signing {
     sign configurations.archives
@@ -152,13 +152,13 @@ uploadArchives {
         mavenDeployer {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-//            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-//                authentication(userName: "$DQ_MAVEN_CENTRAL_USERNAME", password: "$DQ_MAVEN_CENTRAL_APIKEY")
-//            }
-//
-//            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-//                authentication(userName: "$DQ_MAVEN_CENTRAL_USERNAME", password: "$DQ_MAVEN_CENTRAL_APIKEY")
-//            }
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: "$DQ_MAVEN_CENTRAL_USERNAME", password: "$DQ_MAVEN_CENTRAL_APIKEY")
+            }
+
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: "$DQ_MAVEN_CENTRAL_USERNAME", password: "$DQ_MAVEN_CENTRAL_APIKEY")
+            }
 
             pom.project {
                 name 'Axe Android'

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 
 plugins {
     id "com.github.spotbugs" version "1.6.11"
+    id "com.jfrog.artifactory" version "4.4.18"
 }
 
 apply plugin: 'java'
@@ -41,26 +42,25 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
+configurations {
+    spotbugsConfig {
+        canBeConsumed(false)
+        canBeResolved(false)
+    }
+}
 
+dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'com.android.support:support-annotations:24.2.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.jetbrains:annotations:15.0'
-    implementation ("com.google.code.findbugs:annotations:3.0.1") {
-        exclude module: 'jsr305'
-        exclude module: 'jcip-annotations'
-    }
 
     testImplementation 'ar.com.hjg:pngj:2.1.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.7.22'
-}
 
-configurations.all { config ->
-    config.exclude group: 'com.google.code.findbugs'
-    config.exclude group: 'net.jcip', module: 'jcip-annotations'
+    spotbugsConfig "com.google.code.findbugs:annotations:3.0.1"
 }
 
 apply plugin: 'jacoco'
@@ -136,12 +136,12 @@ task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
 }
 
-version = project.hasProperty('versionName') ? project.versionName : 'NOT_A_VERSION_NAME'
+version = "TEST_JAR94"
 
-if (!(hasProperty('DQ_MAVEN_CENTRAL_USERNAME') && hasProperty('DQ_MAVEN_CENTRAL_APIKEY'))) {
-    print ("No artifactory Info. Maven Central Publishing impossible.")
-    return
-}
+//if (!(hasProperty('DQ_MAVEN_CENTRAL_USERNAME') && hasProperty('DQ_MAVEN_CENTRAL_APIKEY'))) {
+//    print ("No artifactory Info. Maven Central Publishing impossible.")
+//    return
+//}
 
 signing {
     sign configurations.archives
@@ -152,13 +152,13 @@ uploadArchives {
         mavenDeployer {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: "$DQ_MAVEN_CENTRAL_USERNAME", password: "$DQ_MAVEN_CENTRAL_APIKEY")
-            }
-
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: "$DQ_MAVEN_CENTRAL_USERNAME", password: "$DQ_MAVEN_CENTRAL_APIKEY")
-            }
+//            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+//                authentication(userName: "$DQ_MAVEN_CENTRAL_USERNAME", password: "$DQ_MAVEN_CENTRAL_APIKEY")
+//            }
+//
+//            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+//                authentication(userName: "$DQ_MAVEN_CENTRAL_USERNAME", password: "$DQ_MAVEN_CENTRAL_APIKEY")
+//            }
 
             pom.project {
                 name 'Axe Android'

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -184,7 +184,7 @@
     </module>
     <module name="AbbreviationAsWordInName">
       <property name="ignoreFinal" value="false"/>
-      <property name="allowedAbbreviationLength" value="1"/>
+      <property name="allowedAbbreviationLength" value="2"/>
     </module>
     <module name="OverloadMethodsDeclarationOrder"/>
     <module name="VariableDeclarationUsageDistance"/>

--- a/src/main/java/com/deque/axe/android/AxeConf.java
+++ b/src/main/java/com/deque/axe/android/AxeConf.java
@@ -17,6 +17,8 @@ import com.deque.axe.android.rules.hierarchy.SwitchName;
 import com.deque.axe.android.rules.hierarchy.TouchSizeWcag;
 import com.deque.axe.android.rules.stateful.DontMoveAccessibilityFocus;
 import com.deque.axe.android.utils.JsonSerializable;
+import com.deque.axe.android.utils.SuppressFBWarnings;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -25,10 +27,13 @@ import java.util.Set;
 
 public class AxeConf {
 
+  @SuppressFBWarnings(
+          value = "URF_UNREAD_FIELD",
+          justification = "This is an object that isn't used for"
+                  + " anything but serialization."
+  )
   static class IssueFilterConf implements JsonSerializable {
-
     boolean onlyShowResultsVisibleToUser = false;
-
   }
 
   static class RuleConf implements JsonSerializable {

--- a/src/main/java/com/deque/axe/android/AxeConf.java
+++ b/src/main/java/com/deque/axe/android/AxeConf.java
@@ -25,10 +25,6 @@ import java.util.Set;
 
 public class AxeConf {
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-          value = "URF_UNREAD_FIELD",
-          justification = "This is an object that isn't used for anything but serialization."
-  )
   static class IssueFilterConf implements JsonSerializable {
 
     boolean onlyShowResultsVisibleToUser = false;

--- a/src/main/java/com/deque/axe/android/utils/SuppressFBWarnings.java
+++ b/src/main/java/com/deque/axe/android/utils/SuppressFBWarnings.java
@@ -1,0 +1,19 @@
+package com.deque.axe.android.utils;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@SuppressWarnings("checkstyle:allowedAbbreviationLength")
+@Retention(RetentionPolicy.CLASS)
+public @interface SuppressFBWarnings {
+  /**
+   * The set of FindBugs warnings that are to be suppressed in annotated element.
+   * The value can be a bug category, kind or pattern.
+   */
+  String[] value() default {};
+
+  /**
+   * Optional documentation of the reason why the warning is suppressed.
+   */
+  String justification() default "";
+}


### PR DESCRIPTION
Closes: #139 the annotations library hasn't been necessary since the plugin was included. The necessary suppression can be handled by a duplicate suppression class, since spotbugs doesn't care where the annotation comes from.

## Requester Review Items

- [x] Ensure the Pull Request is into develop.
- [x] Test coverage has not gone down.
- [x] Documentation updated or not needed. (Wiki, Issues, etc)
- [x] Angular Type leads to proper Semantic Version.

## Dev Team Review Items

To be filled out by @dequelabs/mobile.

- [x] Ensure the Requester did not lie. Chastise them politely if they did.
- [x] Code Quality review.
- [x] Changes to Axe*.java classes are minimal, appropriate, and versioned properly.
  - [x] Serialized Axe objects have not changed.
  - [x] Public API has not changed.

## Code Owner Review Items

To be filled out by @dequelabs/mobileadmin.

- [x] Any Rules package changes lead to proper Semantic Version.
- [x] Security Review.

## Merger Review Items

- [x] Ensure commit message matches title before squashing.


