### PR TITLE
chore: Detect Compose Android Views

### DIFF
--- a/src/main/java/com/deque/axe/android/AxeRuleViewHierarchy.java
+++ b/src/main/java/com/deque/axe/android/AxeRuleViewHierarchy.java
@@ -24,6 +24,10 @@ public abstract class AxeRuleViewHierarchy extends AxeRule {
         AxeProps.Name.OVERRIDES_ACCESSIBILITY_DELEGATE,
         axeView.overridesAccessibilityDelegate
     );
+    axeProps.put(
+        AxeProps.Name.IS_COMPOSE_VIEW,
+        axeView.isComposeView
+    );
     if (axeView.calculatedProps != null
             && axeView.calculatedProps.get(
                     AxePropCalculator.Props.IS_VISIBLE_TO_USER.getProp()) != null) {
@@ -40,7 +44,8 @@ public abstract class AxeRuleViewHierarchy extends AxeRule {
 
   @CallSuper
   public boolean isApplicable(final AxeProps axeProps) {
-    return !axeProps.get(AxeProps.Name.OVERRIDES_ACCESSIBILITY_DELEGATE, Boolean.class);
+    return !axeProps.get(AxeProps.Name.OVERRIDES_ACCESSIBILITY_DELEGATE, Boolean.class)
+            && !axeProps.get(AxeProps.Name.IS_COMPOSE_VIEW, Boolean.class);
   }
 
   public abstract @AxeStatus String runRule(final AxeProps axeProps);

--- a/src/main/java/com/deque/axe/android/AxeView.java
+++ b/src/main/java/com/deque/axe/android/AxeView.java
@@ -136,7 +136,7 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
   static AxeRect contentViewAxeRect;
 
   /**
-   * True if the view overrides AccessibilityDelegate.
+   * True if the view is ComposeView.
    */
   public final boolean isComposeView;
 

--- a/src/main/java/com/deque/axe/android/AxeView.java
+++ b/src/main/java/com/deque/axe/android/AxeView.java
@@ -136,6 +136,11 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
   static AxeRect contentViewAxeRect;
 
   /**
+   * True if the view overrides AccessibilityDelegate.
+   */
+  public final boolean isComposeView;
+
+  /**
    * Library of calculated props name, role, state, value.
    */
   public final Map<String, String> calculatedProps;
@@ -187,6 +192,8 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
 
     AxeColor textColor();
 
+    boolean isComposeView();
+
     default AxeView build() {
       return new AxeView(this);
     }
@@ -212,7 +219,8 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
       final boolean isVisibleToUser,
       final int measuredHeight,
       final int measuredWidth,
-      final AxeColor textColor
+      final AxeColor textColor,
+      final boolean isComposeView
   ) {
     this.boundsInScreen = boundsInScreen;
     this.className = className;
@@ -234,6 +242,7 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
     this.measuredHeight = measuredHeight;
     this.measuredWidth = measuredWidth;
     this.textColor = textColor;
+    this.isComposeView = isComposeView;
 
     setContentView(viewIdResourceName, boundsInScreen);
     this.calculatedProps = calculateProps();
@@ -270,7 +279,8 @@ public class AxeView implements AxeTree<AxeView>, Comparable<AxeView>, JsonSeria
         builder.isVisibleToUser(),
         builder.measuredHeight(),
         builder.measuredWidth(),
-        builder.textColor()
+        builder.textColor(),
+        builder.isComposeView()
     );
   }
 

--- a/src/main/java/com/deque/axe/android/wrappers/AxeProps.java
+++ b/src/main/java/com/deque/axe/android/wrappers/AxeProps.java
@@ -47,7 +47,8 @@ public class AxeProps extends HashMap<String, Object>
       Name.LABELED_BY_VIEW_OVERRIDES_ACCESSIBILITY_DELEGATE,
       Name.IS_VISIBLE_TO_USER,
       Name.MEASURED_HEIGHT,
-      Name.MEASURED_WIDTH
+      Name.MEASURED_WIDTH,
+      Name.IS_COMPOSE_VIEW
   })
   public @interface Name {
     String CLASS_NAME = "className";
@@ -85,6 +86,7 @@ public class AxeProps extends HashMap<String, Object>
     String IS_VISIBLE_TO_USER = "isVisibleToUser";
     String MEASURED_HEIGHT = "measuredHeight";
     String MEASURED_WIDTH = "measuredWidth";
+    String IS_COMPOSE_VIEW = "isAndroidLegacyView";
   }
 
   @Override

--- a/src/test/java/com/deque/axe/android/rules/hierarchy/ActiveViewNameTest.java
+++ b/src/test/java/com/deque/axe/android/rules/hierarchy/ActiveViewNameTest.java
@@ -36,6 +36,8 @@ public class ActiveViewNameTest {
     when(axeProps.get(AxeProps.Name.IS_CLICKABLE, Boolean.class)).thenReturn(true);
     when(axeProps.get(AxeProps.Name.OVERRIDES_ACCESSIBILITY_DELEGATE, Boolean.class))
             .thenReturn(false);
+    when(axeProps.get(AxeProps.Name.IS_COMPOSE_VIEW, Boolean.class))
+            .thenReturn(false);
 
     assertTrue(subject.isApplicable(axeProps));
   }

--- a/src/test/java/com/deque/axe/android/rules/hierarchy/EditTextValueTest.java
+++ b/src/test/java/com/deque/axe/android/rules/hierarchy/EditTextValueTest.java
@@ -44,6 +44,8 @@ public class EditTextValueTest {
             .thenReturn("android.widget.EditText");
     when(axeProps.get(AxeProps.Name.OVERRIDES_ACCESSIBILITY_DELEGATE, Boolean.class))
             .thenReturn(false);
+    when(axeProps.get(AxeProps.Name.IS_COMPOSE_VIEW, Boolean.class))
+            .thenReturn(false);
 
     assertTrue(subject.isApplicable(axeProps));
   }

--- a/src/test/java/com/deque/axe/android/rules/hierarchy/ImageViewNameTest.java
+++ b/src/test/java/com/deque/axe/android/rules/hierarchy/ImageViewNameTest.java
@@ -36,6 +36,8 @@ public class ImageViewNameTest {
             .thenReturn("android.widget.ImageView");
     when(axeProps.get(AxeProps.Name.OVERRIDES_ACCESSIBILITY_DELEGATE, Boolean.class))
             .thenReturn(false);
+    when(axeProps.get(AxeProps.Name.IS_COMPOSE_VIEW, Boolean.class))
+            .thenReturn(false);
 
     assertTrue(subject.isApplicable(axeProps));
   }

--- a/src/test/java/com/deque/axe/android/wrappers/AxeViewBuilder.java
+++ b/src/test/java/com/deque/axe/android/wrappers/AxeViewBuilder.java
@@ -223,6 +223,11 @@ public class AxeViewBuilder implements Builder {
   }
 
   @Override
+  public boolean isComposeView() {
+    return false;
+  }
+
+  @Override
   public boolean isVisibleToUser() {
     return isVisibleToUser;
   }


### PR DESCRIPTION
Closes: [Detect Compose Views](https://app.zenhub.com/workspaces/mobile-5ccf5c056202ac26f233076a/issues/dequelabs/axe-devtools-android/16)

## Requester Review Items

- [x] Ensure the Pull Request is into develop.
- [x] Test coverage has not gone down.
- [x] Documentation updated or not needed. (Wiki, Issues, etc)
- [x] Angular Type leads to proper Semantic Version.

## Dev Team Review Items

To be filled out by @dequelabs/mobile.

- [ ] Ensure the Requester did not lie. Chastise them politely if they did.
- [ ] Code Quality review.
- [ ] Changes to Axe*.java classes are minimal, appropriate, and versioned properly.
  - [ ] Serialized Axe objects have not changed.
  - [ ] Public API has not changed.

## Code Owner Review Items

To be filled out by @dequelabs/mobileadmin.

- [ ] Any Rules package changes lead to proper Semantic Version.
- [ ] Security Review.

## Merger Review Items

- [ ] Ensure commit message matches title before squashing.


